### PR TITLE
Add PUMA: Semantic-Preserving Early Exit for Reasoning Models

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,6 +764,25 @@
                 <td>Math</td>
                 <td>Pass@1,<br>Pass@k</td>
               </tr>
+              <tr>
+                <td><i><b>Stop When Reasoning Converges: Semantic-Preserving Early Exit for Reasoning Models</b></i><br>
+                  <a href="https://arxiv.org/abs/2605.17672" target="_blank">
+                    <img src="https://img.shields.io/badge/arXiv-2605.17672-red" alt="arXiv Badge">
+                  </a>
+                  <a href="https://github.com/giovanni-vaccarino/PUMA" target="_blank">
+                    <img src="https://img.shields.io/badge/Code-GitHub-blue" alt="Code Badge">
+                  </a>
+                </td>
+                <td>Internal</td>
+                <td>✗</td>
+                <td>✗</td>
+                <td>Redundancy-Aware<br>Early Exit</td>
+                <td>✗</td>
+                <td>Trial-Answer<br>Verifier</td>
+                <td>✗</td>
+                <td>Math,<br>Code,<br>General</td>
+                <td>Pass@1,<br>Token Cost,<br>Speedup</td>
+              </tr>
             </tbody>
           </table>
         </div> <!-- end .table-container -->


### PR DESCRIPTION
Adding **PUMA** as a new row in the main taxonomy table in \`index.html\`.

PUMA fits the **inference-time / "How Well: Token Cost + Speedup"** corner of the test-time-scaling landscape — it studies *when to stop scaling* rather than *how to scale up*. It uses reasoning-level semantic redundancy (via a lightweight fine-tuned Qwen3-Embedding-0.6B detector) as the candidate-exit signal, with an answer-verification window confirming exits.

### Taxonomy classification (please feel free to adjust)

| Field | Value | Reasoning |
|---|---|---|
| What | Internal | Modifies the reasoning trajectory in place (early-exit) rather than parallel/sequential sampling |
| SFT | ✗ | The LRM is frozen; only a small auxiliary embedding model is trained |
| RL  | ✗ | — |
| STI | Redundancy-Aware Early Exit | The detector intervenes mid-decoding to flag candidate exit points |
| SEA | ✗ | No tree/graph search |
| VER | Trial-Answer Verifier | The answer-verification window confirms whether a flagged candidate exit is safe |
| AGG | ✗ | — |
| Where | Math, Code, General | MATH-500, AIME24/25, OlympiadBench, GPQA-Diamond + LiveCodeBench + MathVista, MathVision |
| How Well | Pass@1, Token Cost, Speedup | 26.2% average token reduction; 1.40× / 1.28× speedup on DS-7B/14B |

The PUMA detector is contrastively trained, so SFT could arguably be marked ✓ — but I went with ✗ because the LRM itself is untouched and the framework is plug-and-play. Happy to flip if you'd prefer.

### Links

- Paper: https://arxiv.org/abs/2605.17672
- Code:  https://github.com/giovanni-vaccarino/PUMA

I did **not** modify \`papers.json\` (which currently lists only the survey itself) or \`arxiv_citations.json\` (bot-managed). Let me know if I should add to papers.json too.

Thanks!